### PR TITLE
DefaultMachineWindow.update: Skip if target does not exist

### DIFF
--- a/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
+++ b/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
@@ -46,7 +46,10 @@ import org.terasology.workstation.system.WorkstationRegistry;
 import org.terasology.workstation.ui.ProcessListWidget;
 import org.terasology.workstation.ui.WorkstationUI;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class DefaultMachineWindow extends BaseInteractionScreen {
 

--- a/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
+++ b/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
@@ -17,6 +17,8 @@ package org.terasology.machines.ui;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.rendering.nui.UILayout;
 import org.terasology.utilities.Assets;
 import org.terasology.engine.Time;
@@ -71,6 +73,8 @@ public class DefaultMachineWindow extends BaseInteractionScreen {
 
     private String validProcessId;
     private long nextProcessResultRefreshTime;
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMachineWindow.class);
 
     @Override
     public void initialise() {
@@ -244,7 +248,11 @@ public class DefaultMachineWindow extends BaseInteractionScreen {
         final EntityRef interactionTarget = getInteractionTarget();
         if (interactionTarget == null) {
             return;
+        } else if (!interactionTarget.exists()) {
+            logger.error("interaction target does not exist? {} {}", this, interactionTarget);
+            return;
         }
+
 
         if (progressBar != null) {
             // update the progress bar
@@ -300,9 +308,10 @@ public class DefaultMachineWindow extends BaseInteractionScreen {
     private static WorkstationProcess getMostComplexProcess(WorkstationComponent workstation, EntityRef interactionTarget) {
         EntityRef character = CoreRegistry.get(LocalPlayer.class).getCharacterEntity();
         WorkstationRegistry workstationRegistry = CoreRegistry.get(WorkstationRegistry.class);
+        final Collection<WorkstationProcess> processes = workstationRegistry.getWorkstationProcesses(workstation.supportedProcessTypes.keySet());
         // isolate the valid processes to one single process
         WorkstationProcess mostComplexProcess = null;
-        for (WorkstationProcess process : workstationRegistry.getWorkstationProcesses(workstation.supportedProcessTypes.keySet())) {
+        for (WorkstationProcess process : processes) {
             if (process instanceof ValidateProcess) {
                 ValidateProcess validateProcess = (ValidateProcess) process;
                 if (validateProcess.isValid(character, interactionTarget)) {

--- a/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
+++ b/src/main/java/org/terasology/machines/ui/DefaultMachineWindow.java
@@ -45,10 +45,7 @@ import org.terasology.workstation.system.WorkstationRegistry;
 import org.terasology.workstation.ui.ProcessListWidget;
 import org.terasology.workstation.ui.WorkstationUI;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class DefaultMachineWindow extends BaseInteractionScreen {
 
@@ -106,51 +103,15 @@ public class DefaultMachineWindow extends BaseInteractionScreen {
 
     @Override
     protected void initializeWithInteractionTarget(EntityRef interactionTarget) {
-        WorkstationComponent workstation = getInteractionTarget().getComponent(WorkstationComponent.class);
-        MachineDefinitionComponent machineDefinition = getInteractionTarget().getComponent(MachineDefinitionComponent.class);
+        WorkstationComponent workstation = interactionTarget.getComponent(WorkstationComponent.class);
+        MachineDefinitionComponent machineDefinition = interactionTarget.getComponent(MachineDefinitionComponent.class);
         int requirementInputSlots = machineDefinition.requirementSlots;
         int blockInputSlots = machineDefinition.inputSlots;
         int blockOutputSlots = machineDefinition.outputSlots;
 
-        if (inputWidgets != null) {
-            if (machineDefinition.inputWidgets.isEmpty()) {
-                inputWidgets.setContent(null);
-                inputWidgets.setVisible(false);
-            } else {
-                inputWidgets.setVisible(true);
-                FlowLayout widgetLayout = new FlowLayout();
-                for (String widgetUri : machineDefinition.inputWidgets) {
-                    UIElement widgetUIElement = Assets.getUIElement(widgetUri).get();
-                    UIWidget widget = widgetUIElement.getRootWidget();
+        initializeIoWidgets(inputWidgets, interactionTarget, machineDefinition.inputWidgets);
 
-                    if (widget instanceof WorkstationUI) {
-                        ((WorkstationUI) widget).initializeWorkstation(interactionTarget);
-                    }
-                    widgetLayout.addWidget(widget, null);
-                }
-                inputWidgets.setContent(widgetLayout);
-            }
-        }
-
-        if (outputWidgets != null) {
-            if (machineDefinition.outputWidgets.isEmpty()) {
-                outputWidgets.setContent(null);
-                outputWidgets.setVisible(false);
-            } else {
-                outputWidgets.setVisible(true);
-                FlowLayout widgetLayout = new FlowLayout();
-                for (String widgetUri : machineDefinition.outputWidgets) {
-                    UIElement widgetUIElement = Assets.getUIElement(widgetUri).get();
-                    UIWidget widget = widgetUIElement.getRootWidget();
-
-                    if (widget instanceof WorkstationUI) {
-                        ((WorkstationUI) widget).initializeWorkstation(interactionTarget);
-                    }
-                    widgetLayout.addWidget(widget, null);
-                }
-                outputWidgets.setContent(widgetLayout);
-            }
-        }
+        initializeIoWidgets(outputWidgets, interactionTarget, machineDefinition.outputWidgets);
 
         if (ingredients != null) {
             ingredients.setTargetEntity(interactionTarget);
@@ -237,6 +198,33 @@ public class DefaultMachineWindow extends BaseInteractionScreen {
                 }
             }
             outputItems.setContent(itemsLayout);
+        }
+    }
+
+    private static void initializeIoWidgets(UIContainer widgetContainer, EntityRef interactionTarget, Set<String> machineWidgetUris) {
+        if (widgetContainer != null) {
+            if (machineWidgetUris.isEmpty()) {
+                widgetContainer.setContent(null);
+                widgetContainer.setVisible(false);
+            } else {
+                widgetContainer.setVisible(true);
+                FlowLayout widgetLayout = new FlowLayout();
+                for (String widgetUri : machineWidgetUris) {
+                    UIElement widgetUIElement;
+                    Optional<UIElement> uiElementOptional = Assets.getUIElement(widgetUri);
+                    if (!uiElementOptional.isPresent()) {
+                        continue;  // FIXME: log warnings here!
+                    }
+                    widgetUIElement = uiElementOptional.get();
+                    UIWidget widget = widgetUIElement.getRootWidget();
+
+                    if (widget instanceof WorkstationUI) {
+                        ((WorkstationUI) widget).initializeWorkstation(interactionTarget);
+                    }
+                    widgetLayout.addWidget(widget, null);
+                }
+                widgetContainer.setContent(widgetLayout);
+            }
         }
     }
 


### PR DESCRIPTION
this branch is made on top of https://github.com/Terasology/Machines/pull/23

adds a small defensive check to DefaultMachineWindow.update() to bail out if target.exists() is not True, helps defend against things like https://github.com/MovingBlocks/Terasology/issues/2594

although it still strikes me as odd that update() uses getInteractionTarget() at all. Would it be better to use the interactionTarget passed in to initializeWithInteractionTarget?