### PR TITLE
fix: tools with components added in `MachineCommonSystem`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.png  binary
+
+gradlew text eol=lf

--- a/src/main/java/org/terasology/machines/systems/MachineCommonSystem.java
+++ b/src/main/java/org/terasology/machines/systems/MachineCommonSystem.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.fluid.component.FluidInventoryComponent;
+import org.terasology.logic.common.RetainComponentsComponent;
 import org.terasology.logic.inventory.InventoryAccessComponent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.machines.components.MachineDefinitionComponent;
@@ -49,9 +50,12 @@ public class MachineCommonSystem extends BaseComponentSystem {
     }
 
     private void addProcessingMachine(EntityRef entity, MachineDefinitionComponent machineDefinition) {
+        RetainComponentsComponent retainComponents = new RetainComponentsComponent();
 
         // configure the input/output inventories
         if (!entity.hasComponent(InventoryComponent.class) && machineDefinition.inputSlots + machineDefinition.requirementSlots + machineDefinition.outputSlots > 0) {
+            retainComponents.components.add(InventoryComponent.class);
+            entity.addOrSaveComponent(retainComponents);
             int totalSlots = machineDefinition.inputSlots + machineDefinition.requirementSlots + machineDefinition.outputSlots;
             InventoryComponent inventoryComponent = new InventoryComponent(totalSlots);
             inventoryComponent.privateToOwner = false;
@@ -60,6 +64,8 @@ public class MachineCommonSystem extends BaseComponentSystem {
 
         // configure the fluid inventories
         if (!entity.hasComponent(FluidInventoryComponent.class) && machineDefinition.fluidInputSlotVolumes.size() + machineDefinition.fluidOutputSlotVolumes.size() > 0) {
+            retainComponents.components.add(FluidInventoryComponent.class);
+            entity.addOrSaveComponent(retainComponents);
             FluidInventoryComponent fluidInventoryComponent = new FluidInventoryComponent();
             for (float volume : machineDefinition.fluidInputSlotVolumes) {
                 fluidInventoryComponent.fluidSlots.add(EntityRef.NULL);
@@ -74,6 +80,8 @@ public class MachineCommonSystem extends BaseComponentSystem {
 
         // configure the categorized inventory
         if (!entity.hasComponent(InventoryAccessComponent.class) && (entity.hasComponent(InventoryComponent.class) || entity.hasComponent(FluidInventoryComponent.class))) {
+            retainComponents.components.add(InventoryAccessComponent.class);
+            entity.addOrSaveComponent(retainComponents);
             InventoryAccessComponent categorizedInventory = new InventoryAccessComponent();
             categorizedInventory.input = new HashMap();
             categorizedInventory.output = new HashMap();

--- a/src/main/java/org/terasology/machines/systems/MachineCommonSystem.java
+++ b/src/main/java/org/terasology/machines/systems/MachineCommonSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.machines.systems;
 
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -55,7 +56,6 @@ public class MachineCommonSystem extends BaseComponentSystem {
         // configure the input/output inventories
         if (!entity.hasComponent(InventoryComponent.class) && machineDefinition.inputSlots + machineDefinition.requirementSlots + machineDefinition.outputSlots > 0) {
             retainComponents.components.add(InventoryComponent.class);
-            entity.addOrSaveComponent(retainComponents);
             int totalSlots = machineDefinition.inputSlots + machineDefinition.requirementSlots + machineDefinition.outputSlots;
             InventoryComponent inventoryComponent = new InventoryComponent(totalSlots);
             inventoryComponent.privateToOwner = false;
@@ -65,7 +65,6 @@ public class MachineCommonSystem extends BaseComponentSystem {
         // configure the fluid inventories
         if (!entity.hasComponent(FluidInventoryComponent.class) && machineDefinition.fluidInputSlotVolumes.size() + machineDefinition.fluidOutputSlotVolumes.size() > 0) {
             retainComponents.components.add(FluidInventoryComponent.class);
-            entity.addOrSaveComponent(retainComponents);
             FluidInventoryComponent fluidInventoryComponent = new FluidInventoryComponent();
             for (float volume : machineDefinition.fluidInputSlotVolumes) {
                 fluidInventoryComponent.fluidSlots.add(EntityRef.NULL);
@@ -81,7 +80,6 @@ public class MachineCommonSystem extends BaseComponentSystem {
         // configure the categorized inventory
         if (!entity.hasComponent(InventoryAccessComponent.class) && (entity.hasComponent(InventoryComponent.class) || entity.hasComponent(FluidInventoryComponent.class))) {
             retainComponents.components.add(InventoryAccessComponent.class);
-            entity.addOrSaveComponent(retainComponents);
             InventoryAccessComponent categorizedInventory = new InventoryAccessComponent();
             categorizedInventory.input = new HashMap();
             categorizedInventory.output = new HashMap();
@@ -109,6 +107,7 @@ public class MachineCommonSystem extends BaseComponentSystem {
 
             entity.addComponent(categorizedInventory);
         }
+        entity.addOrSaveComponent(retainComponents);
     }
 
     IntegerRange createSlotRange(int startIndex, int length) {


### PR DESCRIPTION
## Contains

This PR fixes the issue that components that are programmatically added in `MachineCommonSystems` are removed in engine's `EntityAwareWorldProvider::updateBlockEntityComponents` if they are neither a "common component" nor part of the blocks prefab.

This issue was observed through the `ManualLabor:AssemblyTable` not showing the assembly slots (`InventoryGrid`s) when placing the assembly table.

By adding a `RetainComponentsComponent` containing the respective components that were added programmatically in `MachineCommonSystem:addProcessingMachine` they are not removed anymore.

## How to test

This fix can be tested by starting JoshariasSurvival, (in-hand) crafting or cheating (`give assemblytable`) an assembly table, placing and opening it.
Without the fix, the assembly slots should not be shown. With the fix they should.
Please note, that the issue only occurred on newly placed assembly tables. When loading a world and an already placed assembly table in it, `EntityAwareWorldProvider::setBlocks` is not called and thus, the programatically added components not removed.

Depends on https://github.com/MovingBlocks/Terasology/pull/3910 that introduces `RetainComponentsComponent`