### PR TITLE
fix: Avoid placing liquids at the same time as filling tanks

### DIFF
--- a/src/main/java/org/terasology/fluidTransport/systems/FluidTankAuthoritySystem.java
+++ b/src/main/java/org/terasology/fluidTransport/systems/FluidTankAuthoritySystem.java
@@ -51,12 +51,14 @@ public class FluidTankAuthoritySystem extends BaseComponentSystem {
                 float amountToFill = Math.min(fluidContainer.maxVolume, outputTankVolume);
                 fillFluidContainer(event, item, outputTankFluidType, amountToFill);
                 ExtendedFluidManager.removeFluid(targetBlockEntity, amountToFill, outputTankFluidType);
+                event.consume();
             } else if (fluidContainer.fluidType != null && fluidContainer.volume <= inputTankEmptyVolume
                     // if the fluid types are the same,  or if the block does not have a fluid type
                     && (inputTankFluidType == null || inputTankFluidType.equals(fluidContainer.fluidType))) {
                 // empty the container to the block
                 ExtendedFluidManager.giveFluid(targetBlockEntity, fluidContainer.volume, fluidContainer.fluidType, true);
                 fillFluidContainer(event, item, null, 0);
+                event.consume();
             }
         }
     }


### PR DESCRIPTION
Fixes a slight bug, present only after https://github.com/Terasology/Fluid/pull/21, where if you place fluid in a tank from a stack of more than 1 full fluid containers containing liquid, it will place it from one of the containers into the tank and from another of the containers into a liquid block. This PR should be harmless even without the associated Fluid PR, but isn't really necessary without it.