### PR TITLE
Add fluid inlet/outlets

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -5,7 +5,7 @@
     "displayName": "Machines",
     "description": "A library for machines",
     "dependencies": [
-        { "id": "Fluid", "minVersion": "1.1.0" },
+        { "id": "FlowingLiquids", "minVersion": "1.3.0", "optional": true },
         { "id": "InGameHelp", "minVersion": "1.1.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "ItemRendering", "minVersion": "1.1.0" },

--- a/src/main/java/org/terasology/fluidTransport/components/FluidInletOutletComponent.java
+++ b/src/main/java/org/terasology/fluidTransport/components/FluidInletOutletComponent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.fluidTransport.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.network.Replicate;
+import org.terasology.world.block.ForceBlockActive;
+
+/**
+ * Marks a block that also has a FluidInventoryComponent as able to exchange fluid with adjacent liquid blocks.
+ */
+@ForceBlockActive
+public class FluidInletOutletComponent implements Component {
+    /** The maximum amount of liquid that can flow into the container, in litres (thousandths of a block) per second. */
+    public float inletRate;
+    /** The maximum amount of liquid that can flow from the container, in litres (thousandths of a block) per second. */
+    public float outletRate;
+
+    public float inletVolume;
+    public float outletVolume;
+}

--- a/src/main/java/org/terasology/fluidTransport/systems/FluidInletOutletSystem.java
+++ b/src/main/java/org/terasology/fluidTransport/systems/FluidInletOutletSystem.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.fluidTransport.systems;
+
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.flowingliquids.world.block.LiquidData;
+import org.terasology.fluid.component.FluidComponent;
+import org.terasology.fluid.component.FluidInventoryComponent;
+import org.terasology.fluid.system.FluidManager;
+import org.terasology.fluid.system.FluidRegistry;
+import org.terasology.fluid.system.FluidUtils;
+import org.terasology.fluidTransport.components.FluidInletOutletComponent;
+import org.terasology.math.JomlUtil;
+import org.terasology.math.Side;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockComponent;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
+
+@RegisterSystem(value = RegisterMode.AUTHORITY, requiresOptional = {"FlowingLiquids"})
+public class FluidInletOutletSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    // This should really be a reference to the value from FluidAuthoritySystem, but that's private and changing it would conflict with pending PRs.
+    private static final float FLUID_PER_BLOCK = 1000;
+    @In
+    EntityManager entityManager;
+    @In
+    FluidRegistry fluidRegistry;
+    @In
+    FluidManager fluidManager;
+    @In
+    WorldProvider worldProvider;
+
+    @In
+    private BlockManager blockManager;
+    private Block air;
+
+    @In
+    private ExtraBlockDataManager extraDataManager;
+    private int flowIndex;
+
+    @Override
+    public void initialise() {
+        air = blockManager.getBlock(BlockManager.AIR_ID);
+        flowIndex = extraDataManager.getSlotNumber(LiquidData.EXTRA_DATA_NAME);
+    }
+
+    @Override
+    public void update(float delta) {
+        for (EntityRef machine : entityManager.getEntitiesWith(FluidInletOutletComponent.class, BlockComponent.class, FluidInventoryComponent.class)) {
+            Vector3ic pos = JomlUtil.from(machine.getComponent(BlockComponent.class).position);
+            FluidInletOutletComponent inletOutlet = machine.getComponent(FluidInletOutletComponent.class);
+            FluidInventoryComponent tank = machine.getComponent(FluidInventoryComponent.class);
+            inletOutlet.inletVolume = Math.min(FLUID_PER_BLOCK, inletOutlet.inletVolume + delta * inletOutlet.inletRate);
+            inletOutlet.outletVolume = Math.min(FLUID_PER_BLOCK, inletOutlet.outletVolume + delta * inletOutlet.outletRate);
+            for (int i = 0; i < tank.fluidSlots.size(); i++) {
+                float maximumVolume = tank.maximumVolumes.get(i);
+                EntityRef fluidSlot = tank.fluidSlots.get(i);
+                FluidComponent fluid = fluidSlot.getComponent(FluidComponent.class);
+                Block liquid = fluid == null ? null : fluidRegistry.getCorrespondingLiquid(fluid.fluidType);
+                float fullness = fluid == null ? 0 : fluid.volume / maximumVolume;
+                int internalHeight = (int) (fullness * LiquidData.MAX_HEIGHT);
+
+                if ((fluid == null || fluid.volume < maximumVolume && liquid != null) && inletOutlet.inletVolume > 0) {
+                    for (Side side : Side.values()) {
+                        if (side == Side.BOTTOM) {
+                            continue;
+                        }
+                        Vector3ic adjPos = side.getAdjacentPos(pos, new Vector3i());
+                        Block adjBlock = worldProvider.getBlock(adjPos);
+                        if (liquid == null ? adjBlock.isLiquid() : adjBlock == liquid) {
+                            byte status = (byte) worldProvider.getExtraData(flowIndex, JomlUtil.from(adjPos));
+                            int externalHeight = LiquidData.getHeight(status) - LiquidData.getRate(status);
+                            int flowRate = (side == Side.TOP) ? Math.min(externalHeight, LiquidData.MAX_HEIGHT - internalHeight - 1) : (externalHeight - internalHeight) / 2;
+                            if (flowRate > 0) {
+                                if (flowRate == externalHeight) {
+                                    worldProvider.setBlock(adjPos, air);
+                                } else {
+                                    worldProvider.setExtraData(flowIndex, JomlUtil.from(adjPos), LiquidData.setHeight(status, LiquidData.getHeight(status) - flowRate));
+                                }
+                                float volume = flowRate * FLUID_PER_BLOCK / LiquidData.MAX_HEIGHT;
+                                fluidManager.addFluid(EntityRef.NULL, machine, i, fluidRegistry.getCorrespondingFluid(adjBlock), volume);
+                                inletOutlet.inletVolume -= volume;
+                                break; // Don't accept liquid from multiple directions at once, for simplicity.
+                            }
+                        }
+                    }
+                }
+
+                if (liquid != null && inletOutlet.outletVolume > 0) {
+                    for (Side side : Side.values()) {
+                        if (side == Side.TOP) {
+                            continue;
+                        }
+                        Vector3ic adjPos = side.getAdjacentPos(pos, new Vector3i());
+                        Block adjBlock = worldProvider.getBlock(adjPos);
+                        if (adjBlock == air || adjBlock == liquid) {
+                            byte status = adjBlock == air ? LiquidData.FULL : (byte) worldProvider.getExtraData(flowIndex, JomlUtil.from(adjPos));
+                            int externalHeight = adjBlock == air ? 0 : LiquidData.getHeight(status);
+                            int flowRate = (side == Side.BOTTOM) ? Math.min(LiquidData.MAX_HEIGHT - externalHeight, internalHeight - 1) : (internalHeight - externalHeight) / 2;
+                            if (flowRate > 0) {
+                                if (adjBlock == air) {
+                                    worldProvider.setBlock(adjPos, liquid);
+                                }
+                                worldProvider.setExtraData(flowIndex, JomlUtil.from(adjPos), LiquidData.setHeight(status, externalHeight + flowRate));
+                                float volume = flowRate * FLUID_PER_BLOCK / LiquidData.MAX_HEIGHT;
+                                fluidManager.removeFluid(EntityRef.NULL, machine, i, fluid.fluidType, volume);
+                                inletOutlet.outletVolume -= volume;
+                                break; // Don't put liquid in multiple directions at once, for simplicity.
+                            }
+                        }
+                    }
+                }
+            }
+            machine.saveComponent(inletOutlet);
+        }
+    }
+}


### PR DESCRIPTION
Add a component for a machine to convert between liquid blocks and fluids, if FlowingLiquids is enabled. With an inlet, a pump and a pipe, it becomes possible to harvest liquids from the environment automatically. It's possible for a machine to be inlet only, outlet only or both.

### How to test:
As this is a background feature, the easiest way to test it would be to test https://github.com/Terasology/IRLCorp/pull/25, which contains a block that uses this feature. You could also try adding the `FluidInletOutletComponent` to other block prefabs with other values of `inletRate` and `outletRate`. 0 is a possible value, but negative values are not valid.