### PR TITLE
chore: bump up patch version. for new snapshot.

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id": "Machines",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": "Josharias",
     "displayName": "Machines",
     "description": "A library for machines",


### PR DESCRIPTION
branch `develop` produces snapshot artifacts with rule '<version>-SNAPSHOT'.
In gradle world 1.0.0-SNAPSHOT < 1.0.0 .

Problem: 
Jenkins resolve module's dependencies by maven repo.
If module A have version 1.0.0 and module B want version 1.0.0 of module A. then Snapshot repositories not used.
-> module B used only master branch.